### PR TITLE
Make security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 0   # security updates only. refs https://docs.github.com/ja/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file


### PR DESCRIPTION
refs https://docs.github.com/ja/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file